### PR TITLE
fix: routes configuration issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ exports.setup = async ({ dirname }) => {
 
   try {
     const { routes } = getTransformedRoutes({ nowConfig: require(path.join(dirname, 'vercel.json')) })
-    config.routes = routes
+    config.routes = routes || []
   } catch (err) {}
 
   const fileList = await glob('**', dirname)


### PR DESCRIPTION
## What is the current behavior?

When `vercel.json` file does not include routes configuration the method `getTransformedRoutes` from [@vercel/routing-utils](https://www.npmjs.com/package/@vercel/routing-utils) (line 15) returns `null`. After that, we define `config.routes` (line 23) to equal the returned routes configuration object - which is supposed to be an array.

Turns out this scenario leads to an error when trying to push to `config.routes` with the `defaultRoutes` object returned from `detectBuilders` method - a method that reads from `/api` directory and return parsed object containing the route names.

<img width="1632" alt="image" src="https://user-images.githubusercontent.com/13663615/153674738-5af018a0-116f-4153-af37-2031d6367a06.png">

## What is the new behavior?

Simply add an `||` operator to evaluate falsy values being returned from `getTransformedRoutes` routes object so an empty array is set to `config.routes`. This way we can gain access to the push property accessed on line 23.



